### PR TITLE
Add support for authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://travis-ci.com/samtherussell/squeezebox-controller.svg?branch=master)](https://travis-ci.com/samtherussell/squeezebox-controller)
 
 
-A python 3 interface for controlling logitech squeezeboxes via the squeezebox server.
+A python 3 interface for controlling logitech squeezeboxes via the squeezebox server or mysqueezebox.com.
 
 The commands are sent over the JSON RPC interface to the local squeeze server.
 
@@ -27,6 +27,26 @@ params = {
 }
 controller.simple_command(params)
 ```
+
+## Controlling via mysqueezebox.com
+
+A username & password need to be provided.
+
+Usage:
+`̀``python
+from squeezebox_controller import SqueezeBoxController
+
+controller = SqueezeBoxController("mysqueezebox.com",
+                                  server_protocol="https",
+                                  username="<my_username>",
+                                  password="<my_password>")
+params = {
+  "player": "Lounge",
+  "command": "PLAY"
+}
+controller.simple_command(params)
+```
+
 
 ## Parameter options:
 

--- a/test/test.py
+++ b/test/test.py
@@ -1,6 +1,7 @@
 
 from squeezebox_controller import SqueezeBoxController, UserException
 import requests
+import requests.cookies
 from unittest.mock import MagicMock, Mock
 import json as json_lib
 
@@ -10,8 +11,7 @@ url = "http://" + ip + ":9000/jsonrpc.js"
 players = [{"name": "a", "playerid": "1"}, {"name": "b", "playerid": "2"}]
 
 req_lookup_table = {
-  '["-", ["player", "count", "?"]]': '{"result": {"_count": 2}}',
-  '["-", ["players", "0", 2]]': '{"result": {"players_loop": ' + json_lib.dumps(players) + '}}'
+  '["", ["serverstatus", 0, 999]]': '{"result": {"player count": 2, "players_loop": ' + json_lib.dumps(players) +' }}'
 }
 
 def get_req_json(params):
@@ -30,6 +30,7 @@ def handle(*args, **kargs):
   player = params[0]
   command = params[1]
   s = json_lib.dumps(params)
+  print(s)
   if s in req_lookup_table:
     ret_val = req_lookup_table[s]
   else:
@@ -39,12 +40,13 @@ def handle(*args, **kargs):
   return ret
 
 requests_lib = Mock(spec=requests)
+cookies = requests_lib.cookies.RequestsCookieJar()
 requests_lib.post = Mock(side_effect=handle)
 
 sbc = SqueezeBoxController(ip, request_lib=requests_lib)
 
 requests_lib.post.reset_mock()
 sbc.simple_command({"player": players[0]["name"], "command": "PLAY"})
-requests_lib.post.assert_called_once_with(url, json=get_req_json([players[0]["playerid"], ["play"]]))
+requests_lib.post.assert_called_once_with(url, cookies=cookies, json=get_req_json([players[0]["playerid"], ["play"]]))
 
 


### PR DESCRIPTION
Controlling a squeezebox setup via mysqueezebox.com is now possible.

Authentication is performed by sending a username & a password to
mysqueezebox.com which replies with an authentication cookie that should
be included in all future requests. The authentication method has been
replicated from the one performed by the web remote control found on
http://www.mysqueezebox.com/index/Home.